### PR TITLE
Add ProcessSampleBuffer functions to various audio effects

### DIFF
--- a/NWaves/Effects/AutowahEffect.cs
+++ b/NWaves/Effects/AutowahEffect.cs
@@ -1,7 +1,7 @@
 ﻿using NWaves.Effects.Base;
 using NWaves.Operations;
 using System;
-using System.Diagnostics; //                                                                                      2022-05-01: J.P.B.
+using System.Diagnostics; 
 
 namespace NWaves.Effects
 {
@@ -101,7 +101,7 @@ namespace NWaves.Effects
         }
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-05-01: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.     
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -163,10 +163,10 @@ namespace NWaves.Effects
         Finish:
             return result;
 
-        } //                                                                                                      2022-05-01: End
+        }
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.  
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -194,7 +194,7 @@ namespace NWaves.Effects
 
             return result;
 
-        } //                                                                                                      2022-07-06: End    J.P.B.
+        } 
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/AutowahEffect.cs
+++ b/NWaves/Effects/AutowahEffect.cs
@@ -122,7 +122,7 @@ namespace NWaves.Effects
             result = false;
 
             if ((sampleBuffer == IntPtr.Zero)
-                || (frameCount <= 0)
+                || (frameCount <= 0) 
                 || (Channel < 1) || (Channel > nChannels)
                 || (nChannels < 1) || (nChannels > MAX_CHANNELS))
             {
@@ -164,6 +164,37 @@ namespace NWaves.Effects
             return result;
 
         } //                                                                                                      2022-05-01: End
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in float[] sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            bool result = false;
+
+            try
+            {
+                unsafe
+                {
+                    fixed (float* p = sampleBuffer)
+                    {
+                        IntPtr ptrSampleBuffer = (IntPtr)p;
+                        result = ProcessSampleBuffer(ptrSampleBuffer, Channel, nChannels, frameCount);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+            return result;
+
+        } //                                                                                                      2022-07-06: End    J.P.B.
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/Base/AudioEffect.cs
+++ b/NWaves/Effects/Base/AudioEffect.cs
@@ -25,5 +25,11 @@ namespace NWaves.Effects.Base
         /// <param name="signal">Signal</param>
         /// <param name="method">Filtering method</param>
         public virtual DiscreteSignal ApplyTo(DiscreteSignal signal, FilteringMethod method = FilteringMethod.Auto) => this.FilterOnline(signal);
+
+        /// <summary>
+        /// Maximum number of interleaved channels in an audio buffer
+        /// </summary>
+        public const int MAX_CHANNELS = 16; //                                                                    2022-04-20 J.P.B.
+
     }
 }

--- a/NWaves/Effects/Base/AudioEffect.cs
+++ b/NWaves/Effects/Base/AudioEffect.cs
@@ -29,7 +29,7 @@ namespace NWaves.Effects.Base
         /// <summary>
         /// Maximum number of interleaved channels in an audio buffer
         /// </summary>
-        public const int MAX_CHANNELS = 16; //                                                                    2022-04-20 J.P.B.
+        public const int MAX_CHANNELS = 16;
 
     }
 }

--- a/NWaves/Effects/BitCrusherEffect.cs
+++ b/NWaves/Effects/BitCrusherEffect.cs
@@ -1,6 +1,6 @@
 ﻿using NWaves.Effects.Base;
 using System;
-using System.Diagnostics; //                                                                                      2022-06-08: J.P.B.
+using System.Diagnostics; 
 
 namespace NWaves.Effects
 {
@@ -50,7 +50,7 @@ namespace NWaves.Effects
 
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-06-08: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -99,10 +99,10 @@ namespace NWaves.Effects
         Finish:
             return result;
 
-        } //                                                                                                      2022-06-08: End
+        }
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel. 
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -130,7 +130,7 @@ namespace NWaves.Effects
 
             return result;
 
-        } //                                                                                                      2022-07-06: End    J.P.B.
+        }
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/BitCrusherEffect.cs
+++ b/NWaves/Effects/BitCrusherEffect.cs
@@ -48,6 +48,7 @@ namespace NWaves.Effects
             return output * Wet + sample * Dry;
         }
 
+
         /// <summary>
         /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-06-08: Start    J.P.B.
         /// </summary>
@@ -99,6 +100,37 @@ namespace NWaves.Effects
             return result;
 
         } //                                                                                                      2022-06-08: End
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in float[] sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            bool result = false;
+
+            try
+            {
+                unsafe
+                {
+                    fixed (float* p = sampleBuffer)
+                    {
+                        IntPtr ptrSampleBuffer = (IntPtr)p;
+                        result = ProcessSampleBuffer(ptrSampleBuffer, Channel, nChannels, frameCount);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+            return result;
+
+        } //                                                                                                      2022-07-06: End    J.P.B.
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/BitCrusherEffect.cs
+++ b/NWaves/Effects/BitCrusherEffect.cs
@@ -1,5 +1,6 @@
 ﻿using NWaves.Effects.Base;
 using System;
+using System.Diagnostics; //                                                                                      2022-06-08: J.P.B.
 
 namespace NWaves.Effects
 {
@@ -46,6 +47,58 @@ namespace NWaves.Effects
 
             return output * Wet + sample * Dry;
         }
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-06-08: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in IntPtr sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            float output;
+            bool result;
+
+            result = false;
+            float t_Dry = Dry;
+            float t_Wet = Wet;
+
+            if ((sampleBuffer == IntPtr.Zero)
+                || (frameCount <= 0)
+                || (Channel < 1) || (Channel > nChannels)
+                || (nChannels < 1) || (nChannels > MAX_CHANNELS))
+            {
+                goto Finish;
+            } //                                         we have a parameter error. Don't change the audio samples.
+
+            try
+            { // parms are OK. process the buffer
+
+                unsafe
+                {
+                    float* p = (float*)sampleBuffer.ToPointer(); //           start with leftmost  channel's first sample
+                    if (Channel != 1) p = p + (Channel - 1); //               reposition to correct channel's first sample
+                    for (int i = 0; i < (int)frameCount; i++) //              process each frame (sample group) in the buffer
+                    {
+                        output = (float)(_step * Math.Floor(*p / _step + 0.5));
+                        *p = output * t_Wet + *p * t_Dry;
+                        p += nChannels; //                                    move to the next frame (sample group) in the buffer           
+                    }
+                }
+
+                result = true;
+
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+        Finish:
+            return result;
+
+        } //                                                                                                      2022-06-08: End
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/DelayEffect.cs
+++ b/NWaves/Effects/DelayEffect.cs
@@ -1,7 +1,7 @@
 ﻿using NWaves.Effects.Base;
 using NWaves.Utils;
-using System; //                                                                                                  2022-04-20: J.P.B.
-using System.Diagnostics; //                                                                                      2022-04-20: J.P.B.
+using System; 
+using System.Diagnostics; 
 
 namespace NWaves.Effects
 {
@@ -84,7 +84,7 @@ namespace NWaves.Effects
         }
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-04-20: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel. 
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -137,10 +137,10 @@ namespace NWaves.Effects
         Finish:
             return result;
 
-        } //                                                                                                      2022-04-20: End
+        }
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel. 
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -168,7 +168,7 @@ namespace NWaves.Effects
 
             return result;
 
-        } //                                                                                                      2022-07-06: End    J.P.B.
+        } 
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/DelayEffect.cs
+++ b/NWaves/Effects/DelayEffect.cs
@@ -1,5 +1,7 @@
 ﻿using NWaves.Effects.Base;
 using NWaves.Utils;
+using System; //                                                                                                  2022-04-20: J.P.B.
+using System.Diagnostics; //                                                                                      2022-04-20: J.P.B.
 
 namespace NWaves.Effects
 {
@@ -80,6 +82,74 @@ namespace NWaves.Effects
 
             return sample * Dry + output * Wet;
         }
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-04-20: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in IntPtr sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            float delayed, output;
+            bool result;
+
+            result = false;
+            float t_Dry = Dry;
+            float t_Wet = Wet;
+            float t_Feedback = Feedback;
+
+            if ((sampleBuffer == IntPtr.Zero)
+                || (frameCount <= 0)
+                || (Channel < 1) || (Channel > nChannels)
+                || (nChannels < 1) || (nChannels > MAX_CHANNELS))
+            {
+                goto Finish; //                                         we have a parameter error. Don't change the audio samples.
+            }
+
+            try
+            { // parms are OK. process the buffer
+
+                unsafe
+                {
+                    float* p = (float*)sampleBuffer.ToPointer(); //           start with leftmost  channel's first sample
+                    if (Channel != 1) p = p + (Channel - 1); //               reposition to correct channel's first sample
+                    for (int i = 0; i < (int)frameCount; i++) //              process each frame (sample group) in the buffer
+                    {
+
+                        delayed = _delayLine.Read(_delay);
+                        _delayLine.Write(*p);
+
+
+
+                        //delayed = _delayLine.GetNext(_delay, *p); //          get _delayLine (Delay Effect's) next sample, and add current 2022-04-22
+                        //                                          //               sample from sampleBuffer to the _delayLine (Delay Effect's) samples
+
+
+
+
+
+
+
+                        output = *p + delayed * t_Feedback;  //               apply delay effect to the current sample in the sampleBuffer
+                        *p = *p * t_Dry + output * t_Wet; //                       "            "             "             "           "
+                        p += nChannels; //                                    move to the next frame (sample group) in the buffer           
+                    }
+                }
+
+                result = true;
+
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+        Finish:
+            return result;
+
+        } //                                                                                                      2022-04-20: End
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/DelayEffect.cs
+++ b/NWaves/Effects/DelayEffect.cs
@@ -120,18 +120,6 @@ namespace NWaves.Effects
 
                         delayed = _delayLine.Read(_delay);
                         _delayLine.Write(*p);
-
-
-
-                        //delayed = _delayLine.GetNext(_delay, *p); //          get _delayLine (Delay Effect's) next sample, and add current 2022-04-22
-                        //                                          //               sample from sampleBuffer to the _delayLine (Delay Effect's) samples
-
-
-
-
-
-
-
                         output = *p + delayed * t_Feedback;  //               apply delay effect to the current sample in the sampleBuffer
                         *p = *p * t_Dry + output * t_Wet; //                       "            "             "             "           "
                         p += nChannels; //                                    move to the next frame (sample group) in the buffer           

--- a/NWaves/Effects/DelayEffect.cs
+++ b/NWaves/Effects/DelayEffect.cs
@@ -140,6 +140,37 @@ namespace NWaves.Effects
         } //                                                                                                      2022-04-20: End
 
         /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in float[] sampleBuffer, in int Channel, in int nChannels, in int frameCount) 
+        {
+            bool result = false;
+
+            try
+            { 
+                unsafe
+                {
+                    fixed (float* p = sampleBuffer)
+                    {
+                        IntPtr ptrSampleBuffer = (IntPtr)p;
+                        result = ProcessSampleBuffer(ptrSampleBuffer, Channel, nChannels, frameCount);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+            return result;
+
+        } //                                                                                                      2022-07-06: End    J.P.B.
+
+        /// <summary>
         /// Resets effect.
         /// </summary>
         public override void Reset()

--- a/NWaves/Effects/DistortionEffect.cs
+++ b/NWaves/Effects/DistortionEffect.cs
@@ -1,6 +1,7 @@
 ﻿using NWaves.Effects.Base;
 using NWaves.Utils;
 using System;
+using System.Diagnostics; //                                                                                      2022-04-25: J.P.B.
 
 namespace NWaves.Effects
 {
@@ -144,6 +145,144 @@ namespace NWaves.Effects
 
             return output * Wet + sample * Dry;
         }
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-04-25: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in IntPtr sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            float delayed, output, sample;
+            bool result;
+
+            result = false;
+            float t_Dry = Dry;
+            float t_Wet = Wet;
+
+            if ((sampleBuffer == IntPtr.Zero)
+                || (frameCount <= 0)
+                || (Channel < 1) || (Channel > nChannels)
+                || (nChannels < 1) || (nChannels > MAX_CHANNELS))
+            {
+                goto Finish;
+            } //                                         we have a parameter error. Don't change the audio samples.
+
+            try
+            { // parms are OK. process the buffer
+
+                unsafe
+                {
+                    float* p = (float*)sampleBuffer.ToPointer(); //           start with leftmost  channel's first sample
+                    if (Channel != 1) p = p + (Channel - 1); //               reposition to correct channel's first sample
+                    for (int i = 0; i < (int)frameCount; i++) //              process each frame (sample group) in the buffer
+                    {
+                        sample = *p * _inputGain;
+
+                        switch (Mode)
+                        {
+                            case DistortionMode.HardClipping:
+
+                                if (sample > 0.5f)
+                                {
+                                    output = 0.5f;
+                                }
+                                else if (sample < -0.5f)
+                                {
+                                    output = -0.5f;
+                                }
+                                else
+                                {
+                                    output = sample;
+                                }
+                                break;
+
+                            case DistortionMode.Exponential:
+
+                                // DAFX book[Udo Zoelzer], p.124 - 125.
+
+                                if (sample > 0)
+                                {
+                                    output = (float)(1 - Math.Exp(-sample));
+                                }
+                                else
+                                {
+                                    output = (float)(-1 + Math.Exp(sample));
+                                }
+                                break;
+
+                            case DistortionMode.FullWaveRectify:
+
+                                output = Math.Abs(sample);
+                                break;
+
+                            case DistortionMode.HalfWaveRectify:
+
+                                if (sample < 0)
+                                {
+                                    output = 0;
+                                }
+                                else
+                                {
+                                    output = Math.Abs(sample);
+                                }
+                                break;
+
+                            case DistortionMode.SoftClipping:
+                            default:
+
+                                // DAFX book[Udo Zoelzer], p.118.
+
+                                const float lowerThreshold = 1 / 3f;
+                                const float upperThreshold = 2 / 3f;
+
+                                if (sample > upperThreshold)
+                                {
+                                    output = 1;
+                                }
+                                else if (sample > lowerThreshold)
+                                {
+                                    output = 1 - (2 - 3 * sample) * (2 - 3 * sample) / 3;
+                                }
+                                else if (sample < -upperThreshold)
+                                {
+                                    output = -1;
+                                }
+                                else if (sample < -lowerThreshold)
+                                {
+                                    output = -1 + (2 + 3 * sample) * (2 + 3 * sample) / 3;
+                                }
+                                else
+                                {
+                                    output = 2 * sample;
+                                }
+
+                                output *= 0.5f;
+
+                                break;
+                        }
+
+                        output *= _outputGain;
+                        *p = output * t_Wet + sample * t_Dry;
+
+                        p += nChannels; //                                    move to the next frame (sample group) in the buffer           
+                    }
+                }
+
+                result = true;
+
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+        Finish:
+            return result;
+
+        } //                                                                                                      2022-04-25: End
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/DistortionEffect.cs
+++ b/NWaves/Effects/DistortionEffect.cs
@@ -163,7 +163,7 @@ namespace NWaves.Effects
             float t_Wet = Wet;
 
             if ((sampleBuffer == IntPtr.Zero)
-                || (frameCount <= 0)
+                || (frameCount <= 0) 
                 || (Channel < 1) || (Channel > nChannels)
                 || (nChannels < 1) || (nChannels > MAX_CHANNELS))
             {
@@ -179,8 +179,8 @@ namespace NWaves.Effects
                     if (Channel != 1) p = p + (Channel - 1); //               reposition to correct channel's first sample
                     for (int i = 0; i < (int)frameCount; i++) //              process each frame (sample group) in the buffer
                     {
-                        sample = *p * _inputGain;
-
+                        sample = *p *  _inputGain;
+  
                         switch (Mode)
                         {
                             case DistortionMode.HardClipping:
@@ -283,6 +283,37 @@ namespace NWaves.Effects
             return result;
 
         } //                                                                                                      2022-04-25: End
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in float[] sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            bool result = false;
+
+            try
+            {
+                unsafe
+                {
+                    fixed (float* p = sampleBuffer)
+                    {
+                        IntPtr ptrSampleBuffer = (IntPtr)p;
+                        result = ProcessSampleBuffer(ptrSampleBuffer, Channel, nChannels, frameCount);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+            return result;
+
+        } //                                                                                                      2022-07-06: End    J.P.B.
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/DistortionEffect.cs
+++ b/NWaves/Effects/DistortionEffect.cs
@@ -1,7 +1,7 @@
 ﻿using NWaves.Effects.Base;
 using NWaves.Utils;
 using System;
-using System.Diagnostics; //                                                                                      2022-04-25: J.P.B.
+using System.Diagnostics; 
 
 namespace NWaves.Effects
 {
@@ -147,7 +147,7 @@ namespace NWaves.Effects
         }
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-04-25: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel. 
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -282,10 +282,10 @@ namespace NWaves.Effects
         Finish:
             return result;
 
-        } //                                                                                                      2022-04-25: End
+        }
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel. 
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -313,7 +313,7 @@ namespace NWaves.Effects
 
             return result;
 
-        } //                                                                                                      2022-07-06: End    J.P.B.
+        } 
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/EchoEffect.cs
+++ b/NWaves/Effects/EchoEffect.cs
@@ -83,6 +83,7 @@ namespace NWaves.Effects
             return sample * Dry + output * Wet;
         }
 
+
         /// <summary>
         /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-04-20: Start    J.P.B.
         /// </summary>
@@ -101,7 +102,7 @@ namespace NWaves.Effects
             float t_Feedback = Feedback;
 
             if ((sampleBuffer == IntPtr.Zero)
-                || (frameCount <= 0)
+                || (frameCount <= 0) 
                 || (Channel < 1) || (Channel > nChannels)
                 || (nChannels < 1) || (nChannels > MAX_CHANNELS))
             {
@@ -137,6 +138,37 @@ namespace NWaves.Effects
             return result;
 
         } //                                                                                                      2022-04-20: End
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in float[] sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            bool result = false;
+
+            try
+            {
+                unsafe
+                {
+                    fixed (float* p = sampleBuffer)
+                    {
+                        IntPtr ptrSampleBuffer = (IntPtr)p;
+                        result = ProcessSampleBuffer(ptrSampleBuffer, Channel, nChannels, frameCount);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+            return result;
+
+        } //                                                                                                      2022-07-06: End    J.P.B.
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/EchoEffect.cs
+++ b/NWaves/Effects/EchoEffect.cs
@@ -1,7 +1,7 @@
 ﻿using NWaves.Effects.Base;
 using NWaves.Utils;
-using System; //                                                                                                  2022-04-20: J.P.B.
-using System.Diagnostics; //                                                                                      2022-04-20: J.P.B.
+using System; 
+using System.Diagnostics; 
 
 namespace NWaves.Effects
 {
@@ -85,7 +85,7 @@ namespace NWaves.Effects
 
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-04-20: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -137,10 +137,10 @@ namespace NWaves.Effects
         Finish:
             return result;
 
-        } //                                                                                                      2022-04-20: End
+        } 
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel. 
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -168,7 +168,7 @@ namespace NWaves.Effects
 
             return result;
 
-        } //                                                                                                      2022-07-06: End    J.P.B.
+        } 
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/FlangerEffect.cs
+++ b/NWaves/Effects/FlangerEffect.cs
@@ -2,6 +2,8 @@
 using NWaves.Signals.Builders;
 using NWaves.Signals.Builders.Base;
 using NWaves.Utils;
+using System; //                                                                                                  2022-04-20: J.P.B.
+using System.Diagnostics; //                                                                                      2022-04-20: J.P.B.
 
 namespace NWaves.Effects
 {
@@ -164,6 +166,65 @@ namespace NWaves.Effects
             return Inverted ? Dry * sample - Wet * Depth * delayedSample
                             : Dry * sample + Wet * Depth * delayedSample;
         }
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-04-20: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in IntPtr sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            float delay, delayedSample;
+            bool result;
+
+            float t_Dry = Dry;
+            float t_Wet = Wet;
+            float t_Feedback = Feedback;
+            float t_Depth = Depth;
+
+            result = false;
+
+            if ((sampleBuffer == IntPtr.Zero)
+                || (frameCount <= 0)
+                || (Channel < 1) || (Channel > nChannels)
+                || (nChannels < 1) || (nChannels > MAX_CHANNELS))
+            {
+                goto Finish;
+            } //                                         we have a parameter error. Don't change the audio samples.
+
+            try
+            { // parms are OK. process the buffer
+
+                unsafe
+                {
+                    float* p = (float*)sampleBuffer.ToPointer(); //           start with leftmost  channel's first sample
+                    if (Channel != 1) p = p + (Channel - 1); //               reposition to correct channel's first sample
+                    for (int i = 0; i < (int)frameCount; i++) //              process each frame (sample group) in the buffer
+                    {
+                        delay = _lfo.NextSample() * _width * _fs;
+                        delayedSample = _delayLine.Read(delay); //            get _delayLine (Delay Effect's) sample
+                        _delayLine.Write(*p + t_Feedback * delayedSample); //   add current sample from sampleBuffer to the _delayLine (Delay Effect's) samples
+                        *p = Inverted ? t_Dry * *p - t_Wet * t_Depth * delayedSample  // apply effect to the current sample in the sampleBuffer
+                                      : t_Dry * *p + t_Wet * t_Depth * delayedSample;
+
+                        p += nChannels; //                                    move to the next frame (sample group) in the buffer
+                    }
+                }
+
+                result = true;
+
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+        Finish:
+            return result;
+
+        } //                                                                                                      2022-04-20: End
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/FlangerEffect.cs
+++ b/NWaves/Effects/FlangerEffect.cs
@@ -2,8 +2,8 @@
 using NWaves.Signals.Builders;
 using NWaves.Signals.Builders.Base;
 using NWaves.Utils;
-using System; //                                                                                                  2022-04-20: J.P.B.
-using System.Diagnostics; //                                                                                      2022-04-20: J.P.B.
+using System; 
+using System.Diagnostics; 
 
 namespace NWaves.Effects
 {
@@ -168,7 +168,7 @@ namespace NWaves.Effects
         }
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-04-20: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -224,10 +224,10 @@ namespace NWaves.Effects
         Finish:
             return result;
 
-        } //                                                                                                      2022-04-20: End
+        } 
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel. 
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -255,7 +255,7 @@ namespace NWaves.Effects
 
             return result;
 
-        } //                                                                                                      2022-07-06: End    J.P.B.
+        } 
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/FlangerEffect.cs
+++ b/NWaves/Effects/FlangerEffect.cs
@@ -187,7 +187,7 @@ namespace NWaves.Effects
             result = false;
 
             if ((sampleBuffer == IntPtr.Zero)
-                || (frameCount <= 0)
+                || (frameCount <= 0) 
                 || (Channel < 1) || (Channel > nChannels)
                 || (nChannels < 1) || (nChannels > MAX_CHANNELS))
             {
@@ -207,8 +207,8 @@ namespace NWaves.Effects
                         delayedSample = _delayLine.Read(delay); //            get _delayLine (Delay Effect's) sample
                         _delayLine.Write(*p + t_Feedback * delayedSample); //   add current sample from sampleBuffer to the _delayLine (Delay Effect's) samples
                         *p = Inverted ? t_Dry * *p - t_Wet * t_Depth * delayedSample  // apply effect to the current sample in the sampleBuffer
-                                      : t_Dry * *p + t_Wet * t_Depth * delayedSample;
-
+                                      : t_Dry * *p + t_Wet * t_Depth * delayedSample;   
+                        
                         p += nChannels; //                                    move to the next frame (sample group) in the buffer
                     }
                 }
@@ -225,6 +225,37 @@ namespace NWaves.Effects
             return result;
 
         } //                                                                                                      2022-04-20: End
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in float[] sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            bool result = false;
+
+            try
+            {
+                unsafe
+                {
+                    fixed (float* p = sampleBuffer)
+                    {
+                        IntPtr ptrSampleBuffer = (IntPtr)p;
+                        result = ProcessSampleBuffer(ptrSampleBuffer, Channel, nChannels, frameCount);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+            return result;
+
+        } //                                                                                                      2022-07-06: End    J.P.B.
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/PhaserEffect.cs
+++ b/NWaves/Effects/PhaserEffect.cs
@@ -2,8 +2,8 @@
 using NWaves.Filters.BiQuad;
 using NWaves.Signals.Builders;
 using NWaves.Signals.Builders.Base;
-using System; //                                                                                                  2022-06-22: J.P.B.
-using System.Diagnostics; //                                                                                      2022-06-22: J.P.B.
+using System; 
+using System.Diagnostics; 
 
 namespace NWaves.Effects
 {
@@ -130,7 +130,7 @@ namespace NWaves.Effects
 
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-06-22: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel. 
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -182,10 +182,10 @@ namespace NWaves.Effects
         Finish:
             return result;
 
-        } //                                                                                                      2022-06-22: End
+        } 
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.     
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -213,7 +213,7 @@ namespace NWaves.Effects
 
             return result;
 
-        } //                                                                                                      2022-07-06: End    J.P.B.
+        } 
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/PhaserEffect.cs
+++ b/NWaves/Effects/PhaserEffect.cs
@@ -2,6 +2,8 @@
 using NWaves.Filters.BiQuad;
 using NWaves.Signals.Builders;
 using NWaves.Signals.Builders.Base;
+using System; //                                                                                                  2022-06-22: J.P.B.
+using System.Diagnostics; //                                                                                      2022-06-22: J.P.B.
 
 namespace NWaves.Effects
 {
@@ -125,6 +127,62 @@ namespace NWaves.Effects
 
             return output * Wet + sample * Dry;
         }
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-06-22: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in IntPtr sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            float output;
+            bool result;
+
+            result = false;
+            float t_Dry = Dry;
+            float t_Wet = Wet;
+            float t_Q = Q;
+
+            if ((sampleBuffer == IntPtr.Zero)
+                || (frameCount <= 0)
+                || (Channel < 1) || (Channel > nChannels)
+                || (nChannels < 1) || (nChannels > MAX_CHANNELS))
+            {
+                goto Finish;
+            } //                                         we have a parameter error. Don't change the audio samples.
+
+            try
+            { // parms are OK. process the buffer
+
+                unsafe
+                {
+                    float* p = (float*)sampleBuffer.ToPointer(); //           start with leftmost  channel's first sample
+                    if (Channel != 1) p = p + (Channel - 1); //               reposition to correct channel's first sample
+                    for (int i = 0; i < (int)frameCount; i++) //              process each frame (sample group) in the buffer
+                    {
+                        output = _filter.Process(*p);
+                        _filter.Change(Lfo.NextSample() / _fs, t_Q);     // vary notch filter coefficients
+                        *p = output * t_Wet + *p * t_Dry;
+
+                        p += nChannels; //                                    move to the next frame (sample group) in the buffer           
+                    }
+                }
+
+                result = true;
+
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+        Finish:
+            return result;
+
+        } //                                                                                                      2022-06-22: End
+
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/PhaserEffect.cs
+++ b/NWaves/Effects/PhaserEffect.cs
@@ -128,6 +128,7 @@ namespace NWaves.Effects
             return output * Wet + sample * Dry;
         }
 
+
         /// <summary>
         /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-06-22: Start    J.P.B.
         /// </summary>
@@ -183,6 +184,36 @@ namespace NWaves.Effects
 
         } //                                                                                                      2022-06-22: End
 
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in float[] sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            bool result = false;
+
+            try
+            {
+                unsafe
+                {
+                    fixed (float* p = sampleBuffer)
+                    {
+                        IntPtr ptrSampleBuffer = (IntPtr)p;
+                        result = ProcessSampleBuffer(ptrSampleBuffer, Channel, nChannels, frameCount);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+            return result;
+
+        } //                                                                                                      2022-07-06: End    J.P.B.
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/TremoloEffect.cs
+++ b/NWaves/Effects/TremoloEffect.cs
@@ -1,8 +1,8 @@
 ﻿using NWaves.Effects.Base;
 using NWaves.Signals.Builders;
 using NWaves.Signals.Builders.Base;
-using System; //                                                                                                  2022-04-20: J.P.B.
-using System.Diagnostics; //                                                                                      2022-04-20: J.P.B.
+using System; 
+using System.Diagnostics; 
 
 namespace NWaves.Effects
 {
@@ -88,7 +88,7 @@ namespace NWaves.Effects
         }
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-04-28: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel. 
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -138,10 +138,10 @@ namespace NWaves.Effects
         Finish:
             return result;
 
-        } //                                                                                                      2022-04-28: End
+        } 
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -169,7 +169,7 @@ namespace NWaves.Effects
 
             return result;
 
-        } //                                                                                                      2022-07-06: End    J.P.B.
+        } 
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/TremoloEffect.cs
+++ b/NWaves/Effects/TremoloEffect.cs
@@ -141,6 +141,37 @@ namespace NWaves.Effects
         } //                                                                                                      2022-04-28: End
 
         /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in float[] sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            bool result = false;
+
+            try
+            {
+                unsafe
+                {
+                    fixed (float* p = sampleBuffer)
+                    {
+                        IntPtr ptrSampleBuffer = (IntPtr)p;
+                        result = ProcessSampleBuffer(ptrSampleBuffer, Channel, nChannels, frameCount);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+            return result;
+
+        } //                                                                                                      2022-07-06: End    J.P.B.
+
+        /// <summary>
         /// Resets effect.
         /// </summary>
         public override void Reset()

--- a/NWaves/Effects/TremoloEffect.cs
+++ b/NWaves/Effects/TremoloEffect.cs
@@ -1,6 +1,8 @@
 ﻿using NWaves.Effects.Base;
 using NWaves.Signals.Builders;
 using NWaves.Signals.Builders.Base;
+using System; //                                                                                                  2022-04-20: J.P.B.
+using System.Diagnostics; //                                                                                      2022-04-20: J.P.B.
 
 namespace NWaves.Effects
 {
@@ -84,6 +86,59 @@ namespace NWaves.Effects
 
             return output * Wet + sample * Dry;
         }
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-04-28: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in IntPtr sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            float delayed, output;
+            bool result;
+
+            result = false;
+            float t_Dry = Dry;
+            float t_Wet = Wet;
+            float t_Depth = Depth;
+
+            if ((sampleBuffer == IntPtr.Zero)
+                || (frameCount <= 0)
+                || (Channel < 1) || (Channel > nChannels)
+                || (nChannels < 1) || (nChannels > MAX_CHANNELS))
+            {
+                goto Finish;
+            } //                                         we have a parameter error. Don't change the audio samples.
+
+            try
+            { // parms are OK. process the buffer
+
+                unsafe
+                {
+                    float* p = (float*)sampleBuffer.ToPointer(); //           start with leftmost  channel's first sample
+                    if (Channel != 1) p = p + (Channel - 1); //               reposition to correct channel's first sample
+                    for (int i = 0; i < (int)frameCount; i++) //              process each frame (sample group) in the buffer
+                    {
+                        output = *p * (1 - t_Depth + t_Depth * Lfo.NextSample());
+                        *p = output * t_Wet + *p * t_Dry;
+                        p += nChannels; //                                    move to the next frame (sample group) in the buffer           
+                    }
+                }
+
+                result = true;
+
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+        Finish:
+            return result;
+
+        } //                                                                                                      2022-04-28: End
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/TubeDistortionEffect.cs
+++ b/NWaves/Effects/TubeDistortionEffect.cs
@@ -139,7 +139,7 @@ namespace NWaves.Effects
             float t_Dist = Dist;
 
             if ((sampleBuffer == IntPtr.Zero)
-                || (frameCount <= 0)
+                || (frameCount <= 0) 
                 || (Channel < 1) || (Channel > nChannels)
                 || (nChannels < 1) || (nChannels > MAX_CHANNELS))
             {
@@ -170,7 +170,7 @@ namespace NWaves.Effects
 
                         output = _outputFilter.Process(output) * _outputGain;
                         *p = output * t_Wet + *p * t_Dry;
-
+                        
                         p += nChannels; //                                    move to the next frame (sample group) in the buffer           
                     }
                 }
@@ -187,6 +187,37 @@ namespace NWaves.Effects
             return result;
 
         } //                                                                                                      2022-04-27: End
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in float[] sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            bool result = false;
+
+            try
+            {
+                unsafe
+                {
+                    fixed (float* p = sampleBuffer)
+                    {
+                        IntPtr ptrSampleBuffer = (IntPtr)p;
+                        result = ProcessSampleBuffer(ptrSampleBuffer, Channel, nChannels, frameCount);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+            return result;
+
+        } //                                                                                                      2022-07-06: End    J.P.B.
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/TubeDistortionEffect.cs
+++ b/NWaves/Effects/TubeDistortionEffect.cs
@@ -2,6 +2,7 @@ using System;
 using NWaves.Effects.Base;
 using NWaves.Filters.Base;
 using NWaves.Utils;
+using System.Diagnostics; //                                                                                      2022-04-27: J.P.B.
 
 namespace NWaves.Effects
 {
@@ -118,6 +119,74 @@ namespace NWaves.Effects
             
             return output * Wet + sample * Dry;
         }
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-04-27: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in IntPtr sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            float delayed, output, q;
+            bool result;
+
+            result = false;
+            float t_Dry = Dry;
+            float t_Wet = Wet;
+            float t_Q = Q;
+            float t_Dist = Dist;
+
+            if ((sampleBuffer == IntPtr.Zero)
+                || (frameCount <= 0)
+                || (Channel < 1) || (Channel > nChannels)
+                || (nChannels < 1) || (nChannels > MAX_CHANNELS))
+            {
+                goto Finish;
+            } //                                         we have a parameter error. Don't change the audio samples.
+
+            try
+            { // parms are OK. process the buffer
+
+                unsafe
+                {
+                    float* p = (float*)sampleBuffer.ToPointer(); //           start with leftmost  channel's first sample
+                    if (Channel != 1) p = p + (Channel - 1); //               reposition to correct channel's first sample
+                    for (int i = 0; i < (int)frameCount; i++) //              process each frame (sample group) in the buffer
+                    {
+                        q = *p * _inputGain;
+
+                        if (Math.Abs(t_Q) < 1e-10)
+                        {
+                            output = Math.Abs(q - t_Q) < 1e-10 ? 1.0f / t_Dist : (float)(q / (1 - Math.Exp(-t_Dist * q)));
+                        }
+                        else
+                        {
+                            output = Math.Abs(q - t_Q) < 1e-10 ?
+                                       (float)(1.0 / t_Dist + t_Q / (1 - Math.Exp(t_Dist * t_Q))) :
+                                       (float)((q - t_Q) / (1 - Math.Exp(-t_Dist * (q - t_Q))) + t_Q / (1 - Math.Exp(t_Dist * t_Q)));
+                        }
+
+                        output = _outputFilter.Process(output) * _outputGain;
+                        *p = output * t_Wet + *p * t_Dry;
+
+                        p += nChannels; //                                    move to the next frame (sample group) in the buffer           
+                    }
+                }
+
+                result = true;
+
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+        Finish:
+            return result;
+
+        } //                                                                                                      2022-04-27: End
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/TubeDistortionEffect.cs
+++ b/NWaves/Effects/TubeDistortionEffect.cs
@@ -2,7 +2,7 @@ using System;
 using NWaves.Effects.Base;
 using NWaves.Filters.Base;
 using NWaves.Utils;
-using System.Diagnostics; //                                                                                      2022-04-27: J.P.B.
+using System.Diagnostics; 
 
 namespace NWaves.Effects
 {
@@ -121,7 +121,7 @@ namespace NWaves.Effects
         }
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-04-27: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel. 
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -186,10 +186,10 @@ namespace NWaves.Effects
         Finish:
             return result;
 
-        } //                                                                                                      2022-04-27: End
+        } 
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -217,7 +217,7 @@ namespace NWaves.Effects
 
             return result;
 
-        } //                                                                                                      2022-07-06: End    J.P.B.
+        } 
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/VibratoEffect.cs
+++ b/NWaves/Effects/VibratoEffect.cs
@@ -153,7 +153,7 @@ namespace NWaves.Effects
             float t_Wet = Wet;
 
             if ((sampleBuffer == IntPtr.Zero)
-                || (frameCount <= 0)
+                || (frameCount <= 0) 
                 || (Channel < 1) || (Channel > nChannels)
                 || (nChannels < 1) || (nChannels > MAX_CHANNELS))
             {
@@ -189,6 +189,37 @@ namespace NWaves.Effects
             return result;
 
         } //                                                                                                      2022-05-03: End
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in float[] sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            bool result = false;
+
+            try
+            {
+                unsafe
+                {
+                    fixed (float* p = sampleBuffer)
+                    {
+                        IntPtr ptrSampleBuffer = (IntPtr)p;
+                        result = ProcessSampleBuffer(ptrSampleBuffer, Channel, nChannels, frameCount);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+            return result;
+
+        } //                                                                                                      2022-07-06: End    J.P.B.
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/VibratoEffect.cs
+++ b/NWaves/Effects/VibratoEffect.cs
@@ -2,6 +2,8 @@
 using NWaves.Signals.Builders;
 using NWaves.Signals.Builders.Base;
 using NWaves.Utils;
+using System; //                                                                                                  2022-04-20: J.P.B.
+using System.Diagnostics; //                                                                                      2022-04-20: J.P.B.
 
 namespace NWaves.Effects
 {
@@ -133,6 +135,60 @@ namespace NWaves.Effects
 
             return Dry * sample + Wet * delayedSample;
         }
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-05-03: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in IntPtr sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            float delay, delayedSample;
+            bool result;
+
+            result = false;
+            float t_Dry = Dry;
+            float t_Wet = Wet;
+
+            if ((sampleBuffer == IntPtr.Zero)
+                || (frameCount <= 0)
+                || (Channel < 1) || (Channel > nChannels)
+                || (nChannels < 1) || (nChannels > MAX_CHANNELS))
+            {
+                goto Finish;
+            } //                                         we have a parameter error. Don't change the audio samples.
+
+            try
+            { // parms are OK. process the buffer
+
+                unsafe
+                {
+                    float* p = (float*)sampleBuffer.ToPointer(); //           start with leftmost  channel's first sample
+                    if (Channel != 1) p = p + (Channel - 1); //               reposition to correct channel's first sample
+                    for (int i = 0; i < (int)frameCount; i++) //              process each frame (sample group) in the buffer
+                    {
+                        delay = _lfo.NextSample() * _width * _fs;
+                        delayedSample = _delayLine.Read(delay);
+                        _delayLine.Write(*p);
+                        *p = t_Dry * *p + t_Wet * delayedSample;
+                        p += nChannels; //                                    move to the next frame (sample group) in the buffer           
+                    }
+                }
+
+                result = true;
+
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+        Finish:
+            return result;
+
+        } //                                                                                                      2022-05-03: End
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/VibratoEffect.cs
+++ b/NWaves/Effects/VibratoEffect.cs
@@ -2,8 +2,8 @@
 using NWaves.Signals.Builders;
 using NWaves.Signals.Builders.Base;
 using NWaves.Utils;
-using System; //                                                                                                  2022-04-20: J.P.B.
-using System.Diagnostics; //                                                                                      2022-04-20: J.P.B.
+using System; 
+using System.Diagnostics; 
 
 namespace NWaves.Effects
 {
@@ -137,7 +137,7 @@ namespace NWaves.Effects
         }
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-05-03: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel. 
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -188,10 +188,10 @@ namespace NWaves.Effects
         Finish:
             return result;
 
-        } //                                                                                                      2022-05-03: End
+        } 
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -219,7 +219,7 @@ namespace NWaves.Effects
 
             return result;
 
-        } //                                                                                                      2022-07-06: End    J.P.B.
+        } 
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/WahwahEffect.cs
+++ b/NWaves/Effects/WahwahEffect.cs
@@ -2,8 +2,8 @@
 using NWaves.Effects.Base;
 using NWaves.Signals.Builders;
 using NWaves.Signals.Builders.Base;
-using System; //                                                                                                  2022-06-26: J.P.B.
-using System.Diagnostics; //                                                                                      2022-06-26: J.P.B.
+using System; 
+using System.Diagnostics; 
 
 namespace NWaves.Effects
 {
@@ -124,7 +124,7 @@ namespace NWaves.Effects
         }
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-06-26: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -179,10 +179,10 @@ namespace NWaves.Effects
         Finish:
             return result;
 
-        } //                                                                                                      2022-06-26: End
+        } 
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -210,7 +210,7 @@ namespace NWaves.Effects
 
             return result;
 
-        } //                                                                                                      2022-07-06: End    J.P.B.
+        } 
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/WahwahEffect.cs
+++ b/NWaves/Effects/WahwahEffect.cs
@@ -2,6 +2,8 @@
 using NWaves.Effects.Base;
 using NWaves.Signals.Builders;
 using NWaves.Signals.Builders.Base;
+using System; //                                                                                                  2022-06-26: J.P.B.
+using System.Diagnostics; //                                                                                      2022-06-26: J.P.B.
 
 namespace NWaves.Effects
 {
@@ -120,6 +122,64 @@ namespace NWaves.Effects
 
             return _yb * Wet + sample * Dry;
         }
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-06-26: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in IntPtr sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            float delayed, output;
+            bool result;
+
+            result = false;
+            float t_Dry = Dry;
+            float t_Wet = Wet;
+            double fs2pi;
+            float f;
+
+            if ((sampleBuffer == IntPtr.Zero)
+                || (frameCount <= 0)
+                || (Channel < 1) || (Channel > nChannels)
+                || (nChannels < 1) || (nChannels > MAX_CHANNELS))
+            {
+                goto Finish;
+            } //                                         we have a parameter error. Don't change the audio samples.
+
+            try
+            { // parms are OK. process the buffer
+
+                unsafe
+                {
+                    float* p = (float*)sampleBuffer.ToPointer(); //           start with leftmost  channel's first sample
+                    if (Channel != 1) p = p + (Channel - 1); //               reposition to correct channel's first sample
+                    for (int i = 0; i < (int)frameCount; i++) //              process each frame (sample group) in the buffer
+                    {
+                        fs2pi = 2.0 * Math.PI / _fs;
+                        f = (float)(2 * Math.Sin(Lfo.NextSample() * fs2pi));
+                        _yh = *p - _yl - Q * _yb;
+                        _yb += f * _yh;
+                        _yl += f * _yb;
+                        *p = _yb * t_Wet + *p * t_Dry;
+                        p += nChannels; //                                    move to the next frame (sample group) in the buffer           
+                    }
+                }
+
+                result = true;
+
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+        Finish:
+            return result;
+
+        } //                                                                                                      2022-06-26: End
 
         /// <summary>
         /// Resets effect.

--- a/NWaves/Effects/WahwahEffect.cs
+++ b/NWaves/Effects/WahwahEffect.cs
@@ -182,6 +182,37 @@ namespace NWaves.Effects
         } //                                                                                                      2022-06-26: End
 
         /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in float[] sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            bool result = false;
+
+            try
+            {
+                unsafe
+                {
+                    fixed (float* p = sampleBuffer)
+                    {
+                        IntPtr ptrSampleBuffer = (IntPtr)p;
+                        result = ProcessSampleBuffer(ptrSampleBuffer, Channel, nChannels, frameCount);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+            return result;
+
+        } //                                                                                                      2022-07-06: End    J.P.B.
+
+        /// <summary>
         /// Resets effect.
         /// </summary>
         public override void Reset()

--- a/NWaves/NWaves.csproj
+++ b/NWaves/NWaves.csproj
@@ -50,4 +50,20 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net5.0|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net5.0|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
 </Project>

--- a/NWaves/Operations/DynamicsProcessor.cs
+++ b/NWaves/Operations/DynamicsProcessor.cs
@@ -188,10 +188,11 @@ namespace NWaves.Operations
             return sample * gain;
         }
 
+
         private float[] _ygMINUSxg = null;//                                                                      2022-05-18: Start    J.P.B.
         private float[] _envelope = null;
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                           
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -206,16 +207,16 @@ namespace NWaves.Operations
             float abs, xg, yg, gain;
 
             result = false;
-
+   
             if ((sampleBuffer == IntPtr.Zero)
-                || (frameCount <= 0)
+                || (frameCount <= 0) 
                 || (Channel < 1) || (Channel > nChannels)
                 || (nChannels < 1) || (nChannels > NWaves.Effects.Base.AudioEffect.MAX_CHANNELS))
             {
                 goto Finish;
             } //                                         we have a parameter error. Don't change the audio samples.
 
-            if (_ygMINUSxg == null || _ygMINUSxg.Length != frameCount)
+            if (_ygMINUSxg == null || _ygMINUSxg.Length != frameCount) 
             {
                 _ygMINUSxg = new float[frameCount];
                 _envelope = new float[frameCount];
@@ -281,6 +282,37 @@ namespace NWaves.Operations
             return result;
 
         } //                                                                                                      2022-05-18: End
+
+        /// <summary>
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// </summary>
+        /// <param name="sampleBuffer">audio sample buffer</param>
+        /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
+        /// <param name="nChannels"># of interleaved Channels in buffer: 1 to MAX_CHANNELS</param>
+        /// <param name="frameCount"># of frames (sample groups) in buffer: 1 to MAX_FRAME_COUNT </param>
+        public bool ProcessSampleBuffer(in float[] sampleBuffer, in int Channel, in int nChannels, in int frameCount)
+        {
+            bool result = false;
+
+            try
+            {
+                unsafe
+                {
+                    fixed (float* p = sampleBuffer)
+                    {
+                        IntPtr ptrSampleBuffer = (IntPtr)p;
+                        result = ProcessSampleBuffer(ptrSampleBuffer, Channel, nChannels, frameCount);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsAttached) { Debugger.Break(); }
+            }
+
+            return result;
+
+        } //                                                                                                      2022-07-06: End    J.P.B.
 
         /// <summary>
         /// Resets dynamics processor.

--- a/NWaves/Operations/DynamicsProcessor.cs
+++ b/NWaves/Operations/DynamicsProcessor.cs
@@ -2,7 +2,7 @@
 using NWaves.Signals;
 using NWaves.Utils;
 using System;
-using System.Diagnostics; //                                                                                      2022-04-20: J.P.B.
+using System.Diagnostics; 
 
 namespace NWaves.Operations
 {
@@ -189,7 +189,7 @@ namespace NWaves.Operations
         }
 
 
-        private float[] _ygMINUSxg = null;//                                                                      2022-05-18: Start    J.P.B.
+        private float[] _ygMINUSxg = null;
         private float[] _envelope = null;
         /// <summary>
         /// Processes a buffer of (possibly) interleaved samples for a single channel.                            
@@ -281,10 +281,10 @@ namespace NWaves.Operations
         Finish:
             return result;
 
-        } //                                                                                                      2022-05-18: End
+        } 
 
         /// <summary>
-        /// Processes a buffer of (possibly) interleaved samples for a single channel.                            2022-07-06: Start    J.P.B.
+        /// Processes a buffer of (possibly) interleaved samples for a single channel.
         /// </summary>
         /// <param name="sampleBuffer">audio sample buffer</param>
         /// <param name="Channel">Channel #: 1 to MAX_CHANNELS</param>
@@ -312,7 +312,7 @@ namespace NWaves.Operations
 
             return result;
 
-        } //                                                                                                      2022-07-06: End    J.P.B.
+        } 
 
         /// <summary>
         /// Resets dynamics processor.

--- a/NWaves/Operations/EnvelopeFollower.cs
+++ b/NWaves/Operations/EnvelopeFollower.cs
@@ -90,7 +90,7 @@ namespace NWaves.Operations
         /// </summary>
         /// <param name="input">Input sample array</param>
         ///  <param name="output">Output sample array</param>
-        public void ProcessArray(in float[] input, ref float[] output)  //                                       2022-05-18: Start
+        public void ProcessArray(in float[] input, ref float[] output) 
         {
             // envelope following is essentially a low-pass filtering
 
@@ -103,7 +103,7 @@ namespace NWaves.Operations
                 output[i] = _env;
             }
 
-        } //                                                                                                      2022-05-18: End
+        } 
 
         /// <summary>
         /// Resets envelope follower.

--- a/NWaves/Operations/EnvelopeFollower.cs
+++ b/NWaves/Operations/EnvelopeFollower.cs
@@ -86,6 +86,26 @@ namespace NWaves.Operations
         }
 
         /// <summary>
+        /// Processes an array of samples.
+        /// </summary>
+        /// <param name="input">Input sample array</param>
+        ///  <param name="output">Output sample array</param>
+        public void ProcessArray(in float[] input, ref float[] output)  //                                       2022-05-18: Start
+        {
+            // envelope following is essentially a low-pass filtering
+
+            float s;
+
+            for (int i = 0; i < input.Length; i++)
+            {
+                s = Math.Abs(input[i]);
+                _env = _env < s ? _ga * _env + (1 - _ga) * s : _gr * _env + (1 - _gr) * s;
+                output[i] = _env;
+            }
+
+        } //                                                                                                      2022-05-18: End
+
+        /// <summary>
         /// Resets envelope follower.
         /// </summary>
         public void Reset()


### PR DESCRIPTION
This update provides 2 new functions for most audio effects:
1) public bool ProcessSampleBuffer(in IntPtr sampleBuffer, in int Channel, in int nChannels, in int frameCount)
- allows unmanaged audio buffers of (possibly) interleaved channels to be processed with a single call per channel
- can be used to directly process audio buffers presented by various audio api's such as PortAudio
2) public bool ProcessSampleBuffer(in float[] sampleBuffer, in int Channel, in int nChannels, in int frameCount)
- allows managed audio buffers of (possibly) interleaved channels to be processed with a single call per channel

The intent is to improve performance and reduce overhead by reducing the # of calls, and performing the updates directly in the source audio buffers.

I use the IntPtr versions in my GuitarAmigo app. They perform very well.