### PR TITLE
Update WaveFile.cs

### DIFF
--- a/NWaves/Audio/WaveFile.cs
+++ b/NWaves/Audio/WaveFile.cs
@@ -126,18 +126,19 @@ namespace NWaves.Audio
                 if (fmtSize == 18 || fmtSize == 40)
                 {
                     var fmtExtraSize = reader.ReadInt16();
-                    // Additional info for the following:  https://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
-                    // Here is a good link from that page for the Extension chunk: https://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
                     // Any non-16bit WAV file should include a format extension chunk describing how the data should be interpreted.
                     var fmtUsedBitsPerSample = reader.ReadInt16(); // Number of bits-per-sample actually used of container-specified bits-per-sample
                     var fmtChannelSpeakerMap = reader.ReadInt32(); // Bitmask/flags indicating which channels are included in the file.
                     var fmtSubFormatCode = reader.ReadInt16(); // Similar to container-level format code (1 = PCM, 3 = IEEE, etc.).
                     var fmtSubFormatRemainder = reader.ReadBytes(14); // Remainder of SubFormat GUID.  Usually just "\x00\x00\x00\x00\x10\x00\x80\x00\x00\xAA\x00\x38\x9B\x71".
-                    // Above link says our AudioFormat dictates whether an extension chunk should actually exist, but we've been lenient to standards up to this point anyways.
                     if (waveFmt.AudioFormat == 0xFFFE)
+                    {
                         waveFmt.AudioFormat = fmtSubFormatCode;
+                    }
                     if (fmtExtraSize > 22)  // Read any leftovers
+                    {
                         reader.ReadBytes(fmtExtraSize - 22);
+                    }
                 }
                 
                 WaveFmt = waveFmt;

--- a/NWaves/Audio/WaveFile.cs
+++ b/NWaves/Audio/WaveFile.cs
@@ -122,13 +122,25 @@ namespace NWaves.Audio
                 waveFmt.Align = reader.ReadInt16();
                 waveFmt.BitsPerSample = reader.ReadInt16();
 
-                WaveFmt = waveFmt;
-
-                if (fmtSize == 18)
+                // Header size might not include sizeof extension block.
+                if (fmtSize == 18 || fmtSize == 40)
                 {
                     var fmtExtraSize = reader.ReadInt16();
-                    reader.ReadBytes(fmtExtraSize);
+                    // Additional info for the following:  https://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
+                    // Here is a good link from that page for the Extension chunk: https://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
+                    // Any non-16bit WAV file should include a format extension chunk describing how the data should be interpreted.
+                    var fmtUsedBitsPerSample = reader.ReasInt16(); // Number of bits-per-sample actually used of container-specified bits-per-sample
+                    var fmtChannelSpeakerMap = reader.ReadInt32(); // Bitmask/flags indicating which channels are included in the file.
+                    var fmtSubFormatCode = reader.ReadInt16(); // Similar to container-level format code (1 = PCM, 3 = IEEE, etc.).
+                    var fmtSubFormatRemainder = reader.ReadBytes(14); // Remainder of SubFormat GUID.  Usually just "\x00\x00\x00\x00\x10\x00\x80\x00\x00\xAA\x00\x38\x9B\x71".
+                    // Above link says our AudioFormat dictates whether an extension chunk should actually exist, but we've been lenient to standards up to this point anyways.
+                    if (waveFmt.AudioFormat == 0xFFFE)
+                        waveFmt.AudioFormat = fmtSubFormatCode;
+                    if (fmtExtraSize > 22)  // Read any leftovers
+                        reader.ReadBytes(fmtExtraSize - 22);
                 }
+                
+                WaveFmt = waveFmt;
 
                 // there may be some wavefile meta info here,
                 // so try to find "data" header in the file:

--- a/NWaves/Audio/WaveFile.cs
+++ b/NWaves/Audio/WaveFile.cs
@@ -129,7 +129,7 @@ namespace NWaves.Audio
                     // Additional info for the following:  https://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
                     // Here is a good link from that page for the Extension chunk: https://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
                     // Any non-16bit WAV file should include a format extension chunk describing how the data should be interpreted.
-                    var fmtUsedBitsPerSample = reader.ReasInt16(); // Number of bits-per-sample actually used of container-specified bits-per-sample
+                    var fmtUsedBitsPerSample = reader.ReadInt16(); // Number of bits-per-sample actually used of container-specified bits-per-sample
                     var fmtChannelSpeakerMap = reader.ReadInt32(); // Bitmask/flags indicating which channels are included in the file.
                     var fmtSubFormatCode = reader.ReadInt16(); // Similar to container-level format code (1 = PCM, 3 = IEEE, etc.).
                     var fmtSubFormatRemainder = reader.ReadBytes(14); // Remainder of SubFormat GUID.  Usually just "\x00\x00\x00\x00\x10\x00\x80\x00\x00\xAA\x00\x38\x9B\x71".


### PR DESCRIPTION
Fix to allow parsing WAV files which use an Extension chunk to describe PCM audio formats greater than 16-bit. Microsoft states that any WAV file with a Bit Depth of more than 16 should use the Extension chunk to describe the Audio Format, but it will still use the same Audio Format constants used in the container-level Audio Format.

When a file uses the Extension chunk to describe a non-custom Audio Format, the container-level Audio Format will be set to `0xFFFE`.
This is currently not handled by `WaveFile`, and at the moment results in no sample data being read.

Link to relevant sources included in code comments.